### PR TITLE
example of how someone might add to the app state

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { AppContext } from '../contexts/App'
 
 interface HeaderProps {
   appTitle: string
@@ -6,8 +7,12 @@ interface HeaderProps {
 
 export const Header = ({ appTitle }: HeaderProps) => {
   return (
-    <header className="header">
-      <span>{appTitle}</span>
-    </header>
+    <AppContext.Consumer>
+      {value => (
+        <header className="header">
+          <span>{appTitle} ({!value.loaded && 'not'} loaded)</span>
+        </header>
+      )}
+    </AppContext.Consumer>
   )
 }

--- a/src/contexts/App.tsx
+++ b/src/contexts/App.tsx
@@ -1,19 +1,22 @@
 import React, { Component, createContext } from "react";
 
-const AppState = {
-  startup: async (container: HTMLDivElement) => {
-    const mapping = await import("../data/map");
-    mapping.initialize(container);
-  }
-}
-
 // main application context
-export const AppContext = createContext(AppState);
+export const AppContext = createContext({
+  loaded: false,
+  startup: async (container: HTMLDivElement) => {}
+});
 
 // main application provider
 export class AppProvider extends Component {
 
-  state = AppState
+  state = {
+    loaded: false,
+    startup: async (container: HTMLDivElement) => {
+      const mapping = await import("../data/map");
+      await mapping.initialize(container);
+      this.setState( { loaded: true } );
+    }
+  }  
 
   render() {
     return (

--- a/src/data/map.ts
+++ b/src/data/map.ts
@@ -33,7 +33,7 @@ view.ui.add(legend, "bottom-left");
  */
 export const initialize = (container: HTMLDivElement) => {
   view.container = container;
-  view
+  return view
     .when()
     .then(_ => {
       // tslint:disable-next-line:no-console

--- a/tests/unit/components/Header.tsx
+++ b/tests/unit/components/Header.tsx
@@ -12,6 +12,6 @@ describe("components/Header", async () => {
   it("should contain header text", () => {
     const { getByText } = render(<Header appTitle="This is a test" />);
     const text = getByText(/^This is a test/);
-    expect(text.innerText).to.equal("This is a test");
+    expect(text.innerText).to.equal("This is a test (not loaded)");
   });
 });


### PR DESCRIPTION
I don't think this should necessarily be merged, but I wanted to go through the exercise of thinking through how someone might add to the app state and have that state be updated by the map.

For example, if you wanted the app to know when the map was loaded, this won't work:

```ts
const AppState = {
  loaded: false,
  startup: async (container: HTMLDivElement) => {
    const mapping = await import("../data/map");
    await mapping.initialize(container);
    // TODO: can't set state here b/c it's not bound to the AppProvider component
    // this.setState( { loaded: true } )
  }
}
```

This PR makes that work and shows whether or not the mpp is loaded in the header:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/662944/52371293-f3828400-2a09-11e9-9e4e-b637031c0d26.png">

There might be a better way to do this, and there's certainly a better way to show the loading state (if that's desired). I just didn't want the fact that `startup()` is not bound to the `AppProvider` to be a stumbling block for people.
