### PR TITLE
remove mounted from state

### DIFF
--- a/src/components/WebMapView.tsx
+++ b/src/components/WebMapView.tsx
@@ -6,22 +6,20 @@ const WebMapView = () => {
   const mapRef = useRef<HTMLDivElement>(null);
   const { setState } = useContext(AppContext);
   
-  let mounted = false;
   // we can let the application
   // context know that the component
   // is mounted and ready
   useEffect(
     () => {
-      mounted = true;
       setState({
-        mounted,
         container: mapRef.current
       });
-      return () => {
-        mounted = false;
-      };
+      // TODO: clean up function?
+      // only thing I could think of here would be to set mapRef.current = null
+      // in the hopes that would end up causing view.container to be set to null
     },
-    [ mapRef.current ]
+    // NOTE: this ensures this is only fired once, like componentDidMount()
+    []
   );
 
   return (

--- a/src/contexts/App.tsx
+++ b/src/contexts/App.tsx
@@ -5,8 +5,7 @@ export interface AppProviderProps {
 }
 
 const initialState = {
-  container: HTMLDivElement,
-  mounted: false
+  container: null as HTMLDivElement
 };
 
 // main application context
@@ -28,15 +27,17 @@ export const AppProvider = ({ children }: AppProviderProps) => {
   // mapping portion of our application
   // and initialize it
   const loadMap = async () => {
-    if (state.mounted && state.container) {
-      const mapping = await import("../data/map");
-      mapping.initialize(state.container);
-    }
+    const mapping = await import("../data/map");
+    mapping.initialize(state.container);
   };
 
   useEffect(
     () => {
+      if (!state.container) {
+        return
+      }
       loadMap();
+      // TODO: return clean up function that sets the view's container to null?
     },
     [ state.container ]
   );


### PR DESCRIPTION
mounted is not needed if state.container is initialized to a falsey value

also only runs WebMapView's useEffect once (i.e. like componentDidMount)

not sure about the best way to return a clean up function yet